### PR TITLE
Add first pass at examples

### DIFF
--- a/examples/basic-usage/main.tf
+++ b/examples/basic-usage/main.tf
@@ -1,0 +1,6 @@
+module "github-ssh-keys" {
+  source = "deanwilson/github-ssh-keys/aws"
+
+  # fetch the ssh key from this user name
+  github_user = "deanwilson"
+}

--- a/examples/multiple-keys/README.md
+++ b/examples/multiple-keys/README.md
@@ -1,0 +1,8 @@
+# Specify a GitHub Key
+
+It's entirely possible to use multiple ssh keys in
+your GitHub account. AWS EC2 only allows a single
+public key in each key pair resource so you'll occasionally
+need to specify which key to deploy. In this module you do that with
+
+``

--- a/examples/multiple-keys/main.tf
+++ b/examples/multiple-keys/main.tf
@@ -1,0 +1,9 @@
+module "github-ssh-keys" {
+  source = "deanwilson/github-ssh-keys/aws"
+
+  # fetch the ssh key from this user name
+  github_user = "deanwilson"
+
+  # use the second key in the aws_key_pair resource
+  github_key_index = "1"
+}

--- a/examples/specify-everything/README.md
+++ b/examples/specify-everything/README.md
@@ -1,0 +1,8 @@
+# Explicitly specify all options
+
+This example shows all the functionality in a single module invocation.
+
+We, as always, specify the GitHub user that we want to fetch our keys from
+with the `github_user` variable. We choose which key we want, the third one
+in this case, using `github_key_index` and we specify the name of the
+`aws_key_pair` resource we want to create with `aws_key_pair_name`.

--- a/examples/specify-everything/main.tf
+++ b/examples/specify-everything/main.tf
@@ -1,0 +1,23 @@
+module "github_key_pair" {
+  source = "hashicorp/consul/aws"
+
+  github_user = "deanwilson"
+  aws_key_pair_name = "deanwilson-from-github"
+
+  # use the third key in the aws_key_pair resource
+  key_index=2
+}
+
+
+module "github-ssh-keys" {
+  source = "deanwilson/github-ssh-keys/aws"
+
+  # fetch the ssh key from this user name
+  github_user = "deanwilson"
+
+  # create the key with a specific name in AWS
+  aws_key_pair_name = "deanwilson-from-github"
+
+  # use the second key in the aws_key_pair resource
+  github_key_index = "1"
+}


### PR DESCRIPTION
This should not be merged and is speculative

Confirm the module path once it's on the registery

Should it be `key_index` vs `github_key_index`?